### PR TITLE
Add support for multiple host address in testserver

### DIFF
--- a/testserver/testserver.go
+++ b/testserver/testserver.go
@@ -397,6 +397,7 @@ func ListenAddrHostOpt(host string) TestServerOpt {
 }
 
 // ListenAddrHostsOpt allows explicitly setting node hosts for multiple nodes.
+// Note: This takes precedence over ListenAddrHostOpt.
 func ListenAddrHostsOpt(hosts ...string) TestServerOpt {
 	return func(args *testServerArgs) {
 		args.listenAddrHosts = hosts
@@ -619,7 +620,7 @@ func NewTestServer(opts ...TestServerOpt) (TestServer, error) {
 	if len(serverArgs.listenAddrHosts) == 0 {
 		serverArgs.listenAddrHosts = make([]string, serverArgs.numNodes)
 		for i := range serverArgs.listenAddrHosts {
-			serverArgs.listenAddrHosts[i] = defaultListenAddrHost
+			serverArgs.listenAddrHosts[i] = serverArgs.listenAddrHost
 		}
 	}
 	for i := 0; i < serverArgs.numNodes; i++ {


### PR DESCRIPTION
As part of this change
1) Support for using multiple listen addresses is added, this will allow to use multiple hosts on the same machine running on same http ports.
2) Support for using custom node options is also added which will allow to spawn more than 3 node on a single machine.
